### PR TITLE
build: 修改 peerjs-server 服务的依赖条件

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-      - peerjs-server
+      peerjs-server:
+        condition: service_started
     networks:
       - app-network
 


### PR DESCRIPTION
- 将 peerjs-server 服务的依赖条件从 service_healthy 改为 service_started