### PR TITLE
chore(database): 设置 MySQL 最大允许包大小

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: seek-self-mysql
     restart: unless-stopped
     environment:
+      MYSQL_MAX_ALLOWED_PACKET: 64M
       MYSQL_ROOT_PASSWORD: root123456
       MYSQL_DATABASE: seek_self
       MYSQL_USER: seek_user


### PR DESCRIPTION
- 在 docker-compose.yml 文件中添加 MYSQL_MAX_ALLOWED_PACKET 环境变量
- 设置 MySQL 最大允许包大小为64M